### PR TITLE
Update github.com/goliatone/go-job to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/dop251/goja_nodejs v0.0.0-20250314160716-c55ecee183c0
 	github.com/goliatone/go-command v0.4.0
-	github.com/goliatone/go-errors v0.4.0
+	github.com/goliatone/go-errors v0.9.0
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TC
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/goliatone/go-command v0.4.0 h1:YYcz1aHmFTe2MHwUrl5DbUqL4spXss/KmgPROaNbzI4=
 github.com/goliatone/go-command v0.4.0/go.mod h1:54ZC8CoBrpkhS9KzuBbzwx3Ovu2gTKzF6CP/vdEtO8I=
-github.com/goliatone/go-errors v0.4.0 h1:nspNImzuaIIv7E/8bgMuKntkC3gf3ClP9mzdtFOf404=
-github.com/goliatone/go-errors v0.4.0/go.mod h1:FiZEC2z5a8SBdRyljC9wFt+IzqZDfrst2dPoqWARbr4=
+github.com/goliatone/go-errors v0.9.0 h1:Jvx5aV+QgSx5ZK4zagOW5YyVCUcqEYZNVZU4V1oqUDQ=
+github.com/goliatone/go-errors v0.9.0/go.mod h1:FiZEC2z5a8SBdRyljC9wFt+IzqZDfrst2dPoqWARbr4=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQuYXQ+6EN5stWmeY/AZqtM8xk9k=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=


### PR DESCRIPTION
## Summary
Updates github.com/goliatone/go-job from current version to v0.9.0.

**Repository**: goliatone/go-job
**Branch**: auto/go-errors-v0.9.0
**Status**: completed
**Commit**: 748bfaf95a01aa264aab5b8d16c94bececab1bd8

## Details
work item executed successfully


## Test Results

<details>
<summary>Test Output</summary>

```
# github.com/goliatone/go-job.test
ld: warning: '/private/var/folders/f2/v8zlq2950cb5259dsx0cxd8w0000gn/T/go-link-3582144695/000023.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ok  	github.com/goliatone/go-job	1.325s

```

</details>





Generated at 2025-09-30 15:36:15 PDT